### PR TITLE
Fix converter producing entries with no dates

### DIFF
--- a/Converter.py
+++ b/Converter.py
@@ -27,6 +27,12 @@ def transform(infile):
         if row['Type'] == 'EXPENSE' or row['Type'] == 'TRANSFER':
             amount = -1 * amount
 
+        # Ivy Wallet export future planned payment with empty date
+        # omits the entry if date is missing
+        if pd.isna(row['Date']):
+            print(f'IGNORED entry with no date: Title "{row["Title"]}" Amount "{amount}" Due at "{row["Due Date"]}"')
+            continue
+        
         # Append the original row to the transformed DataFrame
         transformed_data.append({
             'Date': row['Date'],


### PR DESCRIPTION
this fixes #3 where certain future planned payments are included in the export with missing dates

added logging just incase someone else might be interested in the future transactions

hopefully these few lines will help someone, since this repo is currently linked by https://github.com/jameskokoska/Cashew/issues/496
(which is how i discover this, thank you for your work!)